### PR TITLE
chore: bump runtime to gnome 49

### DIFF
--- a/devpod-wrapper
+++ b/devpod-wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Parse the env var DEVPOD_ADDITIONAL_ENV_VARS set by the desktop application when calling the CLI to propogate env vars back to the host from the sandbox
 function env_to_args() {

--- a/sh.loft.devpod.yaml
+++ b/sh.loft.devpod.yaml
@@ -1,7 +1,7 @@
 id: sh.loft.devpod
 
 runtime: org.gnome.Platform
-runtime-version: '47'
+runtime-version: '49'
 sdk: org.gnome.Sdk
 
 command: "sh.loft.devpod"


### PR DESCRIPTION
also pulls in https://github.com/flathub/sh.loft.devpod/pull/9