### PR TITLE
Support VSCode Extension Point

### DIFF
--- a/codium-wrapper
+++ b/codium-wrapper
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec flatpak-spawn --host flatpak run com.vscodium.codium "$@"

--- a/codium-wrapper
+++ b/codium-wrapper
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec flatpak-spawn --host flatpak run com.vscodium.codium "$@"

--- a/devpod-wrapper
+++ b/devpod-wrapper
@@ -1,46 +1,5 @@
 #!/bin/sh
 
-# Parse the env var DEVPOD_ADDITIONAL_ENV_VARS set by the desktop application when calling the CLI to propogate env vars back to the host from the sandbox
-function env_to_args() {
-    local env_var="DEVPOD_ADDITIONAL_ENV_VARS"
-    local value="${!env_var}"
+export PATH=/usr/bin:/app/editors/codium/bin:/app/tools/devpod/bin:/app/tools/podman/bin:/app/bin
 
-    # Split the value by commas and process each entry
-    IFS=',' read -ra ENTRIES <<< "$value"
-    for entry in "${ENTRIES[@]}"; do
-        if [ -n "$entry" ]; then
-            echo "--env=$entry"
-        fi
-    done
-}
-
-# If we're outside the flatpak, we will run the flatpak command
-if [ -z "${FLATPAK_ID}" ]; then
-	flatpak run --arch=x86_64 --command=devpod-cli sh.loft.devpod "$@"
-	result="$?"
-
-	# In case of error check if the flatpak has been uninstalled, and prompt to
-	# clean up this leftover
-	if [ "${result}" -gt 0 ]; then # I: Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.
-		if ! flatpak list --app | grep -q sh.loft.devpod; then
-			echo "Devpod flatpak is not installed anymore"
-			rm -i "$0"
-		fi
-	fi
-
-	exit "${result}"
-fi
-
-# copy over the binary file if absend
-if [ ! -e "${XDG_DATA_HOME}/devpod-cli" ]; then
-	/usr/bin/cp /app/bin/devpod-bin "${XDG_DATA_HOME}/devpod-cli"
-else
-	# or if it differs IE after an update
-	if ! /usr/bin/cmp --silent /app/bin/devpod-bin "${XDG_DATA_HOME}/devpod-cli"; then
-		/usr/bin/rm -f "${XDG_DATA_HOME}/devpod-cli"
-		/usr/bin/cp /app/bin/devpod-bin "${XDG_DATA_HOME}/devpod-cli"
-	fi
-fi
-
-# We need to have it into this path so that the host is able to open it with flatpak-spawn
-/usr/bin/flatpak-spawn $(env_to_args) --host "${XDG_DATA_HOME}/devpod-cli" "$@"
+exec devpod-desktop "$@"

--- a/devpod-wrapper
+++ b/devpod-wrapper
@@ -1,5 +1,18 @@
 #!/bin/sh
 
-export PATH=/usr/bin:/app/editors/codium/bin:/app/tools/devpod/bin:/app/tools/podman/bin:/app/bin
+DEVPOD_APP_PATH=$XDG_RUNTIME_DIR/app/sh.loft.devpod
+export PATH=/usr/bin:/app/editors/bin:$DEVPOD_APP_PATH/bin
 
-exec devpod-desktop "$@"
+install -Dm755 /app/bin/devpod $DEVPOD_APP_PATH/bin/devpod-cli
+
+for tool_dir in /app/tools/*; do
+  tool_bindir=$tool_dir/bin
+  if [ -d "$tool_bindir" ]; then
+    echo "Adding $tool_bindir to PATH"
+    export PATH=$PATH:$tool_bindir
+  fi
+done
+
+export PATH=$PATH:/app/bin
+
+/app/bin/devpod-desktop "$@"

--- a/editor-wrapper
+++ b/editor-wrapper
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Get the base name of the script (which will be the symlink name if invoked via symlink)
+script_name=$(basename "$0")
+editor=""
+
+case "$script_name" in
+    "codium")
+        editor="com.vscodium.codium"
+        ;;
+    "code")
+        editor="com.visualstudio.code"
+        ;;
+    *)
+        echo "Unsupported editor $script_name"
+        exit 1
+        ;;
+esac
+
+exec flatpak-spawn --host flatpak run $editor "$@"

--- a/sh.loft.devpod.yaml
+++ b/sh.loft.devpod.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=~/.devpod:create
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Flatpak
+  - --filesystem=xdg-run/podman:create
   - --filesystem=xdg-run/keyring
   - --filesystem=xdg-run/tray-icon:create
 
@@ -49,7 +50,7 @@ modules:
       - type: file
         path: devpod-wrapper
       - type: file
-        path: codium-wrapper
+        path: editor-wrapper
     build-commands:
       - ar -x DevPod.deb
       - tar -xf data.tar.gz
@@ -59,8 +60,10 @@ modules:
       - cp devpod-wrapper /app/bin/sh.loft.devpod
       - chmod +x /app/bin/sh.loft.devpod
       - mkdir -p /app/editors/bin
-      - cp codium-wrapper /app/editors/bin/codium
-      - chmod +x /app/editors/bin/codium
+      - cp editor-wrapper /app/editors/bin/editor-wrapper
+      - chmod +x /app/editors/bin/editor-wrapper
+      - ln -sf editor-wrapper /app/editors/bin/codium
+      - ln -sf editor-wrapper /app/editors/bin/code
       - install -Dm644 DevPod.desktop /app/share/applications/sh.loft.devpod.desktop
       - desktop-file-edit --set-key Exec --set-value sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
       - desktop-file-edit --set-icon sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop

--- a/sh.loft.devpod.yaml
+++ b/sh.loft.devpod.yaml
@@ -14,37 +14,18 @@ finish-args:
   - --socket=ssh-auth
   - --socket=gpg-agent
   - --filesystem=~/.devpod:create
-  - --filesystem=~/.ssh:create
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Flatpak
   - --filesystem=xdg-run/keyring
   - --filesystem=xdg-run/tray-icon:create
 
 add-extensions:
-  sh.loft.devpod.editor:
-    directory: editors
-    subdirectories: true
-    version: '24.08'
-    add-ld-path: lib
-    no-autodownload: true
-  sh.loft.devpod.editor.codium:
-    directory: editors/codium
-    version: '24.08'
-    bundle: true
-    no-autodownload: true
-    autodelete: true
   com.visualstudio.code.tool:
     directory: tools
     subdirectories: true
     version: '24.08'
     add-ld-path: lib
     no-autodownload: true
-  com.visualstudio.code.tool.devpod:
-    directory: tools/devpod
-    version: '24.08'
-    bundle: true
-    no-autodownload: true
-    autodelete: true
 
 modules:
   - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
@@ -72,15 +53,14 @@ modules:
     build-commands:
       - ar -x DevPod.deb
       - tar -xf data.tar.gz
-      - install -Dm755 usr/bin/devpod-cli -t /app/tools/devpod/bin
-      - ln -sf /app/tools/devpod/bin/devpod-cli /app/bin/devpod-cli
-      - ln -sf devpod-cli /app/tools/devpod/bin/devpod
+      - install -Dm755 usr/bin/devpod-cli /app/bin/devpod
+      - ln -sf $XDG_RUNTIME_DIR/app/$FLATPAK_ID/bin/devpod-cli /app/bin/devpod-cli
       - install -Dm755 usr/bin/DevPod\ Desktop /app/bin/devpod-desktop
       - cp devpod-wrapper /app/bin/sh.loft.devpod
       - chmod +x /app/bin/sh.loft.devpod
-      - mkdir -p /app/editors/codium/bin
-      - cp codium-wrapper /app/editors/codium/bin/codium
-      - chmod +x /app/editors/codium/bin/codium
+      - mkdir -p /app/editors/bin
+      - cp codium-wrapper /app/editors/bin/codium
+      - chmod +x /app/editors/bin/codium
       - install -Dm644 DevPod.desktop /app/share/applications/sh.loft.devpod.desktop
       - desktop-file-edit --set-key Exec --set-value sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
       - desktop-file-edit --set-icon sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
@@ -88,3 +68,4 @@ modules:
       - install -Dm644 usr/share/icons/hicolor/32x32/apps/DevPod\ Desktop.png /app/share/icons/hicolor/32x32/apps/sh.loft.devpod.png
       - install -Dm644 usr/share/icons/hicolor/256x256@2/apps/DevPod\ Desktop.png /app/share/icons/hicolor/256x256/apps/sh.loft.devpod.png
       - install -Dm644 DevPod.metainfo.xml /app/share/metainfo/sh.loft.devpod.metainfo.xml
+      - mkdir -p /app/tools

--- a/sh.loft.devpod.yaml
+++ b/sh.loft.devpod.yaml
@@ -13,10 +13,38 @@ finish-args:
   - --share=network
   - --socket=ssh-auth
   - --socket=gpg-agent
-  - --filesystem=home
-  - --talk-name=org.freedesktop.Flatpak
+  - --filesystem=~/.devpod:create
+  - --filesystem=~/.ssh:create
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.Flatpak
   - --filesystem=xdg-run/keyring
+  - --filesystem=xdg-run/tray-icon:create
+
+add-extensions:
+  sh.loft.devpod.editor:
+    directory: editors
+    subdirectories: true
+    version: '24.08'
+    add-ld-path: lib
+    no-autodownload: true
+  sh.loft.devpod.editor.codium:
+    directory: editors/codium
+    version: '24.08'
+    bundle: true
+    no-autodownload: true
+    autodelete: true
+  com.visualstudio.code.tool:
+    directory: tools
+    subdirectories: true
+    version: '24.08'
+    add-ld-path: lib
+    no-autodownload: true
+  com.visualstudio.code.tool.devpod:
+    directory: tools/devpod
+    version: '24.08'
+    bundle: true
+    no-autodownload: true
+    autodelete: true
 
 modules:
   - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
@@ -39,13 +67,20 @@ modules:
         sha256: 32e010e8e2f0806090109d283263d48077a67898d430bddc70c91b46ee359911
       - type: file
         path: devpod-wrapper
+      - type: file
+        path: codium-wrapper
     build-commands:
       - ar -x DevPod.deb
       - tar -xf data.tar.gz
-      - cp devpod-wrapper /app/bin/devpod-cli
-      - chmod +x /app/bin/devpod-cli
-      - install -Dm755 usr/bin/devpod-cli /app/bin/devpod-bin
-      - install -Dm755 usr/bin/DevPod\ Desktop /app/bin/sh.loft.devpod
+      - install -Dm755 usr/bin/devpod-cli -t /app/tools/devpod/bin
+      - ln -sf /app/tools/devpod/bin/devpod-cli /app/bin/devpod-cli
+      - ln -sf devpod-cli /app/tools/devpod/bin/devpod
+      - install -Dm755 usr/bin/DevPod\ Desktop /app/bin/devpod-desktop
+      - cp devpod-wrapper /app/bin/sh.loft.devpod
+      - chmod +x /app/bin/sh.loft.devpod
+      - mkdir -p /app/editors/codium/bin
+      - cp codium-wrapper /app/editors/codium/bin/codium
+      - chmod +x /app/editors/codium/bin/codium
       - install -Dm644 DevPod.desktop /app/share/applications/sh.loft.devpod.desktop
       - desktop-file-edit --set-key Exec --set-value sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop
       - desktop-file-edit --set-icon sh.loft.devpod /app/share/applications/sh.loft.devpod.desktop


### PR DESCRIPTION
Support `com.visualstudio.code.tool` extension point. ~, and introduce a new extension `com.visualstudio.code.tool.devpod` which contains the `devpod-cli` binary required to establish an SSH connection.~

~Also, create a new extension point `sh.loft.devpod.editor` to support creating wrappers for various IDEs.
The extension `sh.loft.devpod.editor.codium` is provided for executing Flatpak VSCodium.~

Resolves #4 