### PR TITLE
Fix: Incorrect shebang in devpod-wrapper causes script fail

### DIFF
--- a/devpod-wrapper
+++ b/devpod-wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Parse the env var DEVPOD_ADDITIONAL_ENV_VARS set by the desktop application when calling the CLI to propogate env vars back to the host from the sandbox
 function env_to_args() {


### PR DESCRIPTION
In the current version of the flatpak (v0.6.10) an incorrect shebang in the `devpod-wrapper` script causes the script to be executed by `sh` instead of a full `bash` instance, which breaks it before the actual devpod cli is called:
```bash
user@localhost:~$ devpod
/home/user/.local/bin/devpod: 4: Syntax error: "(" unexpected
```
Once the shebang is instead set to `#!/usr/bin/env bash` it again works as expected.